### PR TITLE
Extended Document for attributes (so you can add 'boost="xx"')

### DIFF
--- a/lib/delsolr/document.rb
+++ b/lib/delsolr/document.rb
@@ -37,6 +37,10 @@ module DelSolr
   #
   class Document
 
+    def initialize(options={})
+      @options = options
+    end
+
     # [<b><tt>field_mame</tt></b>]
     #         is the name of the field in your schema.xml
     # [<b><tt>value</tt></b>]
@@ -50,7 +54,7 @@ module DelSolr
     end
 
     def xml
-      "<doc>\n" + field_buffer + "</doc>"
+      "<doc#{opts2str(@options)}>\n" + field_buffer + "</doc>"
     end
 
     private
@@ -59,14 +63,8 @@ module DelSolr
     def construct_field_tag(name, value, options={})
       options[:name] = name.to_s
       use_cdata = options.delete(:cdata)
-      opts = []
-      options.each do |k,v| 
-        opts.push "#{k}=\"#{v}\""
-      end
-      opts = opts.join(" ")
-      opts = " " + opts if opts
 
-      return "<field#{opts}>#{use_cdata ? cdata(value) : value}</field>\n"
+      return "<field#{opts2str(options)}>#{use_cdata ? cdata(value) : value}</field>\n"
     end  
 
     def cdata(str)
@@ -75,6 +73,16 @@ module DelSolr
 
     def field_buffer
       @buffer ||= ""
+    end
+
+    def opts2str(options)
+      opts = []
+      options.each do |k,v|
+        opts.push "#{k}=\"#{v}\""
+      end
+      opts = opts.join(" ")
+      opts = " " + opts unless opts.blank?
+      opts
     end
 
   end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -14,6 +14,17 @@ class DocumentTest < Test::Unit::TestCase
     
     assert_equal(buf, d.xml)
   end
+
+  def test_create_with_boost
+    d = DelSolr::Document.new :boost => 2.5
+    assert(d)
+    
+    d.add_field('person_name', 'John Smith')
+    
+    buf = "<doc boost=\"2.5\">\n<field name=\"person_name\">John Smith</field>\n</doc>"
+    
+    assert_equal(buf, d.xml)
+  end
   
   def test_cdata
     d = DelSolr::Document.new
@@ -25,5 +36,5 @@ class DocumentTest < Test::Unit::TestCase
     
     assert_equal(buf, d.xml)
   end
-  
+
 end


### PR DESCRIPTION
Hey avvo!
First of all, thanks for your great work on delsolr. 

But I was missing a 'boost' attribute option on a DelSolr::Document, so I added it.
See code + test attached..

Cheers Tobi
