### PR TITLE
bumped faraday to 0.8.10 and updated Error ClientError

### DIFF
--- a/delsolr.gemspec
+++ b/delsolr.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["License.txt", "Rakefile", "README.rdoc"]
   s.test_files = Dir.glob('test/*_test.rb')
 
-  s.add_dependency("faraday", ["~> 0.8.8"])
+  s.add_dependency("faraday", ["~> 0.8.10"])
   s.add_dependency("json")
 
   s.add_development_dependency("mocha", [">= 0.9.0"])

--- a/lib/delsolr/client.rb
+++ b/lib/delsolr/client.rb
@@ -154,7 +154,7 @@ module DelSolr
       if body.blank? # cache miss (or wasn't enabled)
         response = begin
           connection.post("#{configuration.path}/select", query_builder.request_string)
-        rescue Faraday::ClientError => e
+        rescue Faraday::Error::ClientError => e
           raise ConnectionError, e.message
         end
 


### PR DESCRIPTION
Faraday::ClientError is now invalida. This updates it to Faraday::Error::ClientError