### PR TITLE
[PLTF-1720] Publish Avvo gems to both Packagecloud and Artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+version: 2.1
+
+orbs:
+  artifact-management: avvo/artifact-management@0.0.6
+
+jobs:
+  test:
+    docker:
+      - image: avvo/ruby-testing
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASS
+
+    steps:
+      - checkout
+      - artifact-management/gem-test
+
+  build:
+    docker:
+      - image: circleci/ruby:2.6
+    steps:
+      - checkout
+      - artifact-management/gem-build-and-push
+
+workflows:
+  version: 2.1
+  build-workflow:
+    jobs:
+      - test:
+          context: org-global
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+      - build:
+          requires:
+          - test
+          context: org-global
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+            branches:
+              ignore: /.*/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
 
     steps:
       - checkout
-      - artifact-management/gem-test
+      - artifact-management/gem-test:
+            ruby_versions: "2.2.10,2.3.8,2.4.10,2.5.8,2.6.6"
 
   build:
     docker:

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'mocha'
-
-group :test do
-  gem 'test-unit'
-end

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 Version Changes
 ===============
+
+0.3.4pre4
+---------
+* Update to publish Avvo gem to both Packagecloud and Artifactory
+* Refactor CircleCi configuration to test with multiple Ruby versions.
+
 0.1.6
 -----
 * Added a way to return spelling correction per word

--- a/README.rdoc
+++ b/README.rdoc
@@ -7,6 +7,14 @@ http://delsolr.rubyforge.org
 DelSolr is a light weight ruby wrapper for solr.  It's intention is to expose the full power of solr queries 
 while keeping the interface as ruby-esque as possible.
 
+== Tested Ruby Versions
+Version       Result
+2.6.6         Pass
+2.5.8         Pass
+2.4.10        Pass
+2.3.8         Pass
+2.2.10        Pass
+
 == Installation
 
 Can be installed as a gem which is hosted on http://gemcutter.org

--- a/delsolr.gemspec
+++ b/delsolr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "delsolr"
-  s.version = "0.3.3"
+  s.version = "0.3.4pre4"
   s.authors = ["Ben VandenBos"]
   s.date = %q{2009-11-02}
   s.description = "Ruby wrapper for Lucene Solr"

--- a/delsolr.gemspec
+++ b/delsolr.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency("faraday", ["~> 0.9.0"])
   s.add_dependency("json")
 
+  s.add_development_dependency("test-unit")
   s.add_development_dependency("mocha", [">= 0.9.0"])
   s.add_development_dependency("rake", ["0.9.2"])
 end


### PR DESCRIPTION
@nickmarden This PR is special because it start to implement Gemfile.lock resolution. Please check if next steps are according to expectations:
1) As it is a library next dependencies were move from Gemfile to gemspec:
mocha for general
test-unit for test
2) Gemfile.lock was already listed in .gitignore (if was not, it would be added)